### PR TITLE
Add '-' to replacement regex

### DIFF
--- a/src/org-search.ts
+++ b/src/org-search.ts
@@ -3,7 +3,7 @@ import * as sourcegraph from 'sourcegraph'
 export function activate(): void {
    sourcegraph.search.registerQueryTransformer({
        transformQuery: (query: string) => {
-           const orgRegex = /\borg:(\w*)/
+           const orgRegex = /\borg:([\w-]*)/
            if (query.match(orgRegex)) {
                const orgFilter = query.match(orgRegex)
                const org = orgFilter && orgFilter.length >= 1 ? orgFilter[1] : ''


### PR DESCRIPTION
Closes #4. Just adding `-` to the replacement regex to support organizations with hyphen in their name.